### PR TITLE
Feat: Make timestamp field in polvo-logger mutable and flexible (Issue #1)

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,7 +17,9 @@ type LogMessage struct {
 }
 
 // BuildLog constructs the log message using a structured type.
-func BuildLog(source, eventName, eventLog string, metadata map[string]interface{}) (*LogMessage, error) {
+// The 'timestamp' parameter is optional. If it's an empty string, the current time is used.
+// Otherwise, it will be accepted if it matches one of the allowed layouts.
+func BuildLog(source, eventName, eventLog, timestamp string, metadata map[string]interface{}) (*LogMessage, error) {
 	// Validate required fields.
 	if source == "" {
 		return nil, errors.New("source cannot be empty")
@@ -29,23 +31,45 @@ func BuildLog(source, eventName, eventLog string, metadata map[string]interface{
 		return nil, errors.New("eventLog cannot be empty")
 	}
 
+	// Define multiple acceptable layouts.
+	layouts := []string{
+		"2006-01-02T15:04:05Z07:00",           // RFC3339
+		"2006-01-02T15:04:05.000000Z07:00",    // microsecond precision
+		"2006-01-02T15:04:05.999999999Z07:00", // nanosecond precision
+	}
+
+	// If no timestamp provided, use current time.
+	if timestamp == "" {
+		timestamp = time.Now().Format(layouts[0])
+	} else {
+		valid := false
+		for _, layout := range layouts {
+			if _, err := time.Parse(layout, timestamp); err == nil {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			return nil, errors.New("invalid timestamp format")
+		}
+	}
+
 	return &LogMessage{
 		EventName: eventName,
 		Source:    source,
-		Timestamp: time.Now().Format("2006-01-02T15:04:05.000000Z07:00"),
+		Timestamp: timestamp,
 		Log:       eventLog,
 		Metadata:  metadata,
 	}, nil
 }
 
 // PrintLog prints the unified log message as a one-line JSON string.
-func PrintLog(source, eventName, eventLog string, metadata map[string]interface{}) {
-	logMsg, err := BuildLog(source, eventName, eventLog, metadata)
+func PrintLog(source, eventName, eventLog, timestamp string, metadata map[string]interface{}) {
+	logMsg, err := BuildLog(source, eventName, eventLog, timestamp, metadata)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
-	// Marshal without indent (one-line)
 	b, err := json.Marshal(logMsg)
 	if err != nil {
 		fmt.Println("Error marshalling JSON:", err)
@@ -55,13 +79,12 @@ func PrintLog(source, eventName, eventLog string, metadata map[string]interface{
 }
 
 // PrintLogPretty prints the unified log message as a pretty-printed JSON.
-func PrintLogPretty(source, eventName, eventLog string, metadata map[string]interface{}) {
-	logMsg, err := BuildLog(source, eventName, eventLog, metadata)
+func PrintLogPretty(source, eventName, eventLog, timestamp string, metadata map[string]interface{}) {
+	logMsg, err := BuildLog(source, eventName, eventLog, timestamp, metadata)
 	if err != nil {
 		fmt.Println("Error:", err)
 		return
 	}
-	// Marshal with indentation for pretty printing
 	b, err := json.MarshalIndent(logMsg, "", "  ")
 	if err != nil {
 		fmt.Println("Error marshalling JSON:", err)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -50,7 +50,7 @@ func BuildLog(source, eventName, eventLog, timestampStr string, metadata map[str
 			}
 		}
 		if !valid {
-			return nil, errors.New("invalid timestamp format")
+			return nil, errors.New("invalid timestamp string format, only RFC3339 and its variations are accepted")
 		}
 	}
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -19,7 +19,7 @@ type LogMessage struct {
 // BuildLog constructs the log message using a structured type.
 // The 'timestamp' parameter is optional. If it's an empty string, the current time is used.
 // Otherwise, it will be accepted if it matches one of the allowed layouts.
-func BuildLog(source, eventName, eventLog, timestamp string, metadata map[string]interface{}) (*LogMessage, error) {
+func BuildLog(source, eventName, eventLog, timestampStr string, metadata map[string]interface{}) (*LogMessage, error) {
 	// Validate required fields.
 	if source == "" {
 		return nil, errors.New("source cannot be empty")
@@ -39,12 +39,12 @@ func BuildLog(source, eventName, eventLog, timestamp string, metadata map[string
 	}
 
 	// If no timestamp provided, use current time.
-	if timestamp == "" {
-		timestamp = time.Now().Format(layouts[0])
+	if timestampStr == "" {
+		timestampStr = time.Now().Format(layouts[0])
 	} else {
 		valid := false
 		for _, layout := range layouts {
-			if _, err := time.Parse(layout, timestamp); err == nil {
+			if _, err := time.Parse(layout, timestampStr); err == nil {
 				valid = true
 				break
 			}
@@ -57,7 +57,7 @@ func BuildLog(source, eventName, eventLog, timestamp string, metadata map[string
 	return &LogMessage{
 		EventName: eventName,
 		Source:    source,
-		Timestamp: timestamp,
+		Timestamp: timestampStr,
 		Log:       eventLog,
 		Metadata:  metadata,
 	}, nil

--- a/main.go
+++ b/main.go
@@ -15,20 +15,16 @@ func main() {
 		"user_name":    "alice",
 	}
 
-	// Toggle pretty print. Set to false to print in a single line.
-	pretty := true
+	// Test 1: Using an empty timestamp string (auto-fills current time)
+	emptyTimestamp := ""
+	fmt.Println("Test 1: Logger with empty timestamp (auto current time):")
+	logger.PrintLogPretty("eBPF", "openat", "File descriptor opened successfully", emptyTimestamp, metadata)
 
-	if pretty {
-		fmt.Println("Log message (pretty printed):")
-		logger.PrintLogPretty("eBPF", "openat", "File descriptor opened successfully", metadata)
-	} else {
-		fmt.Println("Log message (one-liner):")
-		logger.PrintLog("eBPF", "openat", "File descriptor opened successfully", metadata)
-	}
-
-	// Directly print a network event in one-line format.
-	fmt.Println("Network event log (one-liner):")
-	logger.PrintLog("libpcap", "connect", "Established connection to 192.168.1.100:80", map[string]interface{}{
+	// Test 2: Using a valid timestamp string
+	// Note: This valid timestamp must match the layout "2006-01-02T15:04:05.000000Z07:00".
+	customTimestamp := "2004-09-26T12:34:56.123456+00:00"
+	fmt.Println("\nTest 2: Logger with valid timestamp:")
+	logger.PrintLog("libpcap", "connect", "Established connection to 192.168.1.100:80", customTimestamp, map[string]interface{}{
 		"ip":   "192.168.1.100",
 		"port": 80,
 	})


### PR DESCRIPTION
This pull request's `polvo-logger` enables `timestamp` field may be mutable. If nothing's provided, it automatically calculates the time and put the timestamp string into it. If the valid timestamp string is manually provided, `polvo-logger` uses it instead.