### PR TITLE
Feat: Implement event object pool to decrease GC pressure due to repeatedly object memory reallocations

### DIFF
--- a/logger/objPool.go
+++ b/logger/objPool.go
@@ -16,6 +16,16 @@ const (
 )
 
 var (
+	modelMapper = map[eventModel.EventCode]func() any{
+		eventModel.PROC_CREATE:        func() any { return &eventModel.ProcessCreateEvent{} },
+		eventModel.PROC_TERMINATE:     func() any { return &eventModel.ProcessTerminateEvent{} },
+		eventModel.PROC_BASH_READLINE: func() any { return &eventModel.BashReadlineEvent{} },
+		eventModel.PROC_SERVICE:       func() any { return &eventModel.ServiceEvent{} },
+		eventModel.TCP_CONNECT:        func() any { return &eventModel.TcpConnectEvent{} },
+		eventModel.TCP_DISCONNECT:     func() any { return &eventModel.TcpDisconnectEvent{} },
+		eventModel.FILE_EVENT:         func() any { return &eventModel.FileEvent{} },
+	}
+
 	SingletonPool = newObjectPool()
 )
 
@@ -45,27 +55,13 @@ func newObjectPool() Pool {
 
 	newPool.eventPoolMap = sync.Map{}
 
-	// TODO: add all event pools to the object pool
-	// create procCreate event pool
-	newPool.eventPoolMap.Store(eventModel.PROC_CREATE, &sync.Pool{
-		New: func() any {
-			return &eventModel.ProcessCreateEvent{}
-		},
-	})
+	for eventCode, newFunc := range modelMapper {
+		newPool.eventPoolMap.Store(eventCode, &sync.Pool{
+			New: newFunc,
+		})
+	}
 
-	// create procTerminate event pool
-	newPool.eventPoolMap.Store(eventModel.PROC_TERMINATE, &sync.Pool{
-		New: func() any {
-			return &eventModel.ProcessTerminateEvent{}
-		},
-	})
-
-	// create bashReadline event pool
-	newPool.eventPoolMap.Store(eventModel.PROC_BASH_READLINE, &sync.Pool{
-		New: func() any {
-			return &eventModel.BashReadlineEvent{}
-		},
-	})
+	// create
 	return newPool
 }
 

--- a/model/commonModel.go
+++ b/model/commonModel.go
@@ -1,10 +1,49 @@
 // model/commonModel.go
 package commonModel
 
-import "time"
+import (
+	"time"
+)
+
+// EventCode defines the event code type.
+type EventCode int
+
+// Event codes
+const (
+	PROC_CREATE EventCode = iota
+	PROC_TERMINATE
+	PROC_BASH_READLINE
+	PROC_SERVICE
+	TCP_CONNECT
+	TCP_DISCONNECT
+	FILE_EVENT
+)
+
+// EventCodeToString converts an EventCode to its string representation.
+func (e EventCode) String() string {
+	switch e {
+	case PROC_CREATE:
+		return "ProcessCreate"
+	case PROC_TERMINATE:
+		return "ProcessTerminate"
+	case PROC_BASH_READLINE:
+		return "BashReadline"
+	case PROC_SERVICE:
+		return "Service"
+	case TCP_CONNECT:
+		return "TcpConnect"
+	case TCP_DISCONNECT:
+		return "TcpDisconnect"
+	case FILE_EVENT:
+		return "FileEvent"
+	default:
+		return ""
+	}
+}
 
 // CommonHeader defines the common header structure for all events.
 type CommonHeader struct {
+	EventCode EventCode `json:"-"`         // example: 1
 	EventName string    `json:"Eventname"` // example: "ProcessCreate"
 	Source    string    `json:"Source"`    // example: "eBPF"
 	Timestamp time.Time `json:"Timestamp"` // example: "2023-10-01T12:00:00Z"

--- a/model/entity/model.go
+++ b/model/entity/model.go
@@ -1,5 +1,5 @@
 // model/entity/model.go
-package model
+package entityModel
 
 import (
 	state "github.com/enki-polvo/polvo-logger/model/state"

--- a/model/event/model.go
+++ b/model/event/model.go
@@ -1,49 +1,13 @@
 // event/model.go
-package model
+package eventModel
 
 import (
 	commonModel "github.com/enki-polvo/polvo-logger/model"
 	state "github.com/enki-polvo/polvo-logger/model/state"
 )
 
-// EventCode defines the event code type.
-type EventCode int
-
 // Event defines the interface for all event types.
 type Event any
-
-// Event codes
-const (
-	PROC_CREATE EventCode = iota
-	PROC_TERMINATE
-	PROC_BASH_READLINE
-	PROC_SERVICE
-	TCP_CONNECT
-	TCP_DISCONNECT
-	FILE_EVENT
-)
-
-// EventCodeToString converts an EventCode to its string representation.
-func (e EventCode) String() string {
-	switch e {
-	case PROC_CREATE:
-		return "ProcessCreate"
-	case PROC_TERMINATE:
-		return "ProcessTerminate"
-	case PROC_BASH_READLINE:
-		return "BashReadline"
-	case PROC_SERVICE:
-		return "Service"
-	case TCP_CONNECT:
-		return "TcpConnect"
-	case TCP_DISCONNECT:
-		return "TcpDisconnect"
-	case FILE_EVENT:
-		return "FileEvent"
-	default:
-		return ""
-	}
-}
 
 // --------------------------------------------------
 // Event metadata

--- a/model/event/model.go
+++ b/model/event/model.go
@@ -17,6 +17,7 @@ const (
 	PROC_CREATE EventCode = iota
 	PROC_TERMINATE
 	PROC_BASH_READLINE
+	PROC_SERVICE
 	TCP_CONNECT
 	TCP_DISCONNECT
 	FILE_EVENT
@@ -31,6 +32,8 @@ func (e EventCode) String() string {
 		return "ProcessTerminate"
 	case PROC_BASH_READLINE:
 		return "BashReadline"
+	case PROC_SERVICE:
+		return "Service"
 	case TCP_CONNECT:
 		return "TcpConnect"
 	case TCP_DISCONNECT:

--- a/model/state/model.go
+++ b/model/state/model.go
@@ -1,5 +1,5 @@
 // model/state/model.go
-package model
+package stateModel
 
 // State defines the state of an entities and events.
 type State int

--- a/pool/README.md
+++ b/pool/README.md
@@ -1,0 +1,42 @@
+# Pool
+
+`Pool` is a feature provided to increase memory reusability in the log processing pipeline of polvo's applications.
+It is recommended that the `Pool` be managed as a **Singleton** at the program's runtime.
+
+## Example
+
+Here is an example usage:
+
+```Go
+import (
+    ...
+    eventModel "github.com/enki-polvo/polvo-logger/model/event"
+    eventPool "github.com/enki-polvo/polvo-logger/pool"
+)
+
+var pool = eventPool.NewEventPool()
+
+...
+
+func PrintProcCreate() error  {
+    // Get object from pool
+    logModel, err := pool.Allocate(eventModel.PROC_CREATE)
+    if err != nil {
+        return err
+    }
+    
+    // Print logModel
+    ...
+    
+    // Free method returns object to pool
+    err = pool.Free(eventModel.PROC_CREATE, logModel)
+    if err != nil {
+        return err
+    }
+    
+    return nil
+}
+
+```
+
+Pool is basically threadSafe so can be used in multiple goroutines.

--- a/pool/README.md
+++ b/pool/README.md
@@ -30,7 +30,7 @@ func PrintProcCreate() error  {
     ...
     
     // Free method returns object to pool
-    err = pool.Free(model.PROC_CREATE, logModel)
+    err = pool.Free(logModel)
     if err != nil {
         return err
     }

--- a/pool/README.md
+++ b/pool/README.md
@@ -11,6 +11,7 @@ Here is an example usage:
 import (
     ...
     eventModel "github.com/enki-polvo/polvo-logger/model/event"
+    model "github.com/enki-polvo/polvo-logger/model"
     eventPool "github.com/enki-polvo/polvo-logger/pool"
 )
 
@@ -20,7 +21,7 @@ var pool = eventPool.NewEventPool()
 
 func PrintProcCreate() error  {
     // Get object from pool
-    logModel, err := pool.Allocate(eventModel.PROC_CREATE)
+    logModel, err := pool.Allocate(model.PROC_CREATE)
     if err != nil {
         return err
     }
@@ -29,7 +30,7 @@ func PrintProcCreate() error  {
     ...
     
     // Free method returns object to pool
-    err = pool.Free(eventModel.PROC_CREATE, logModel)
+    err = pool.Free(model.PROC_CREATE, logModel)
     if err != nil {
         return err
     }

--- a/pool/eventPool.go
+++ b/pool/eventPool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	model "github.com/enki-polvo/polvo-logger/model"
 	eventModel "github.com/enki-polvo/polvo-logger/model/event"
 )
 
@@ -15,21 +16,21 @@ const (
 )
 
 var (
-	modelMapper = map[eventModel.EventCode]func() any{
-		eventModel.PROC_CREATE:        func() any { return &eventModel.ProcessCreateEvent{} },
-		eventModel.PROC_TERMINATE:     func() any { return &eventModel.ProcessTerminateEvent{} },
-		eventModel.PROC_BASH_READLINE: func() any { return &eventModel.BashReadlineEvent{} },
-		eventModel.PROC_SERVICE:       func() any { return &eventModel.ServiceEvent{} },
-		eventModel.TCP_CONNECT:        func() any { return &eventModel.TcpConnectEvent{} },
-		eventModel.TCP_DISCONNECT:     func() any { return &eventModel.TcpDisconnectEvent{} },
-		eventModel.FILE_EVENT:         func() any { return &eventModel.FileEvent{} },
+	modelMapper = map[model.EventCode]func() any{
+		model.PROC_CREATE:        func() any { return &eventModel.ProcessCreateEvent{} },
+		model.PROC_TERMINATE:     func() any { return &eventModel.ProcessTerminateEvent{} },
+		model.PROC_BASH_READLINE: func() any { return &eventModel.BashReadlineEvent{} },
+		model.PROC_SERVICE:       func() any { return &eventModel.ServiceEvent{} },
+		model.TCP_CONNECT:        func() any { return &eventModel.TcpConnectEvent{} },
+		model.TCP_DISCONNECT:     func() any { return &eventModel.TcpDisconnectEvent{} },
+		model.FILE_EVENT:         func() any { return &eventModel.FileEvent{} },
 	}
 )
 
 // Pool interface defines the methods for the object pool.
 type Pool interface {
-	Allocate(eventName eventModel.EventCode) (eventModel.Event, error)
-	Free(eventName eventModel.EventCode, event eventModel.Event) error
+	Allocate(eventName model.EventCode) (eventModel.Event, error)
+	Free(eventName model.EventCode, event eventModel.Event) error
 }
 
 // eventPool implements the Pool interface.
@@ -54,7 +55,7 @@ func NewEventPool() Pool {
 }
 
 // Allocate retrieves an event model from the pool.
-func (op *eventPool) Allocate(eventName eventModel.EventCode) (eventModel.Event, error) {
+func (op *eventPool) Allocate(eventName model.EventCode) (eventModel.Event, error) {
 	var (
 		value     any
 		eventPool *sync.Pool
@@ -76,7 +77,7 @@ func (op *eventPool) Allocate(eventName eventModel.EventCode) (eventModel.Event,
 }
 
 // Free puts an event model back into the pool.
-func (op *eventPool) Free(eventName eventModel.EventCode, event eventModel.Event) error {
+func (op *eventPool) Free(eventName model.EventCode, event eventModel.Event) error {
 	var (
 		value     any
 		eventPool *sync.Pool

--- a/pool/eventPool.go
+++ b/pool/eventPool.go
@@ -17,20 +17,55 @@ const (
 
 var (
 	modelMapper = map[model.EventCode]func() any{
-		model.PROC_CREATE:        func() any { return &eventModel.ProcessCreateEvent{} },
-		model.PROC_TERMINATE:     func() any { return &eventModel.ProcessTerminateEvent{} },
-		model.PROC_BASH_READLINE: func() any { return &eventModel.BashReadlineEvent{} },
-		model.PROC_SERVICE:       func() any { return &eventModel.ServiceEvent{} },
-		model.TCP_CONNECT:        func() any { return &eventModel.TcpConnectEvent{} },
-		model.TCP_DISCONNECT:     func() any { return &eventModel.TcpDisconnectEvent{} },
-		model.FILE_EVENT:         func() any { return &eventModel.FileEvent{} },
+		model.PROC_CREATE: func() any {
+			obj := &eventModel.ProcessCreateEvent{}
+			obj.CommonHeader.EventCode = model.PROC_CREATE
+			obj.CommonHeader.EventName = model.PROC_CREATE.String()
+			return obj
+		},
+		model.PROC_TERMINATE: func() any {
+			obj := &eventModel.ProcessTerminateEvent{}
+			obj.CommonHeader.EventCode = model.PROC_TERMINATE
+			obj.CommonHeader.EventName = model.PROC_TERMINATE.String()
+			return obj
+		},
+		model.PROC_BASH_READLINE: func() any {
+			obj := &eventModel.BashReadlineEvent{}
+			obj.CommonHeader.EventCode = model.PROC_BASH_READLINE
+			obj.CommonHeader.EventName = model.PROC_BASH_READLINE.String()
+			return obj
+		},
+		model.PROC_SERVICE: func() any {
+			obj := &eventModel.ServiceEvent{}
+			obj.CommonHeader.EventCode = model.PROC_SERVICE
+			obj.CommonHeader.EventName = model.PROC_SERVICE.String()
+			return obj
+		},
+		model.TCP_CONNECT: func() any {
+			obj := &eventModel.TcpConnectEvent{}
+			obj.CommonHeader.EventCode = model.TCP_CONNECT
+			obj.CommonHeader.EventName = model.TCP_CONNECT.String()
+			return obj
+		},
+		model.TCP_DISCONNECT: func() any {
+			obj := &eventModel.TcpDisconnectEvent{}
+			obj.CommonHeader.EventCode = model.TCP_DISCONNECT
+			obj.CommonHeader.EventName = model.TCP_DISCONNECT.String()
+			return obj
+		},
+		model.FILE_EVENT: func() any {
+			obj := &eventModel.FileEvent{}
+			obj.CommonHeader.EventCode = model.FILE_EVENT
+			obj.CommonHeader.EventName = model.FILE_EVENT.String()
+			return obj
+		},
 	}
 )
 
 // Pool interface defines the methods for the object pool.
 type Pool interface {
 	Allocate(eventName model.EventCode) (eventModel.Event, error)
-	Free(eventName model.EventCode, event eventModel.Event) error
+	Free(event eventModel.Event) error
 }
 
 // eventPool implements the Pool interface.
@@ -77,13 +112,16 @@ func (op *eventPool) Allocate(eventName model.EventCode) (eventModel.Event, erro
 }
 
 // Free puts an event model back into the pool.
-func (op *eventPool) Free(eventName model.EventCode, event eventModel.Event) error {
+func (op *eventPool) Free(event eventModel.Event) error {
 	var (
 		value     any
 		eventPool *sync.Pool
 		isExists  bool
+		eventName model.EventCode
 	)
 
+	// get event name from event
+	eventName = event.(model.CommonModel).EventCode
 	// check if event pool exists
 	value, isExists = op.eventPoolMap.Load(eventName)
 	if !isExists {

--- a/pool/eventPool_test.go
+++ b/pool/eventPool_test.go
@@ -147,7 +147,7 @@ func TestStressTestMultipleGoroutines(t *testing.T) {
 	var wg sync.WaitGroup
 	var errChan chan error
 
-	errChan = make(chan error, 0)
+	errChan = make(chan error, 10)
 	defer close(errChan)
 
 	for i := 0; i < 10; i++ {
@@ -192,7 +192,7 @@ func TestStressTestInvalidInMultipleGoroutines(t *testing.T) {
 
 	var wg sync.WaitGroup
 	var errChan chan error
-	errChan = make(chan error, 0)
+	errChan = make(chan error, 10)
 	defer close(errChan)
 
 	for i := 0; i < 10; i++ {

--- a/pool/eventPool_test.go
+++ b/pool/eventPool_test.go
@@ -39,7 +39,7 @@ func TestAllocateEvent(t *testing.T) {
 		t.Fatalf("Allocated event is not of type ProcessCreateEvent")
 	}
 	// Free the event back to the pool
-	err = pool.Free(eventCode, event)
+	err = pool.Free(event)
 	if err != nil {
 		t.Fatalf("Failed to free event: %v", err)
 	}
@@ -76,24 +76,25 @@ func TestFreeEvent(t *testing.T) {
 		t.Fatal("Allocated event is nil")
 	}
 
-	err = pool.Free(eventCode, event)
+	err = pool.Free(event)
 	if err != nil {
 		t.Fatalf("Failed to free event: %v", err)
 	}
 }
 
-// Test Freeing of an invalid event
-// Test that freeing an invalid event code returns an error
-func TestFreeInvalidEvent(t *testing.T) {
-	pool := eventPool.NewEventPool()
-	invalidEventCode := model.EventCode(999)  // Assuming 999 is not a valid event code
-	event := &eventModel.ProcessCreateEvent{} // Create a dummy event
+// (DEPRECATED) Test Freeing of an invalid event
+// // Test Freeing of an invalid event
+// // Test that freeing an invalid event code returns an error
+// func TestFreeInvalidEvent(t *testing.T) {
+// 	pool := eventPool.NewEventPool()
+// 	invalidEventCode := model.EventCode(999)  // Assuming 999 is not a valid event code
+// 	event := &eventModel.ProcessCreateEvent{} // Create a dummy event
 
-	err := pool.Free(invalidEventCode, event)
-	if err == nil {
-		t.Fatal("Expected error when freeing invalid event, but got none")
-	}
-}
+// 	err := pool.Free(event)
+// 	if err == nil {
+// 		t.Fatal("Expected error when freeing invalid event, but got none")
+// 	}
+// }
 
 // Test Stress Test for Allocating and Freeing Events
 // This test checks the performance of allocating and freeing events in a loop
@@ -111,7 +112,7 @@ func TestStressTestAllocateFree(t *testing.T) {
 			t.Fatal("Allocated event is nil")
 		}
 
-		err = pool.Free(eventCode, event)
+		err = pool.Free(event)
 		if err != nil {
 			t.Fatalf("Failed to free event: %v", err)
 		}
@@ -166,7 +167,7 @@ func TestStressTestMultipleGoroutines(t *testing.T) {
 					return
 				}
 
-				err = pool.Free(eventCode, event)
+				err = pool.Free(event)
 				if err != nil {
 					errChan <- fmt.Errorf("failed to free event: %v", err)
 					return
@@ -211,7 +212,7 @@ func TestStressTestInvalidInMultipleGoroutines(t *testing.T) {
 					return
 				}
 				time.Sleep(1 * time.Millisecond) // Simulate some delay
-				pool.Free(invalidEventCode, event)
+				pool.Free(event)
 				if err == nil {
 					errChan <- fmt.Errorf("expected error when freeing invalid event, but got none")
 					return

--- a/pool/eventPool_test.go
+++ b/pool/eventPool_test.go
@@ -7,6 +7,7 @@ import (
 
 	"fmt"
 
+	model "github.com/enki-polvo/polvo-logger/model"
 	eventModel "github.com/enki-polvo/polvo-logger/model/event"
 	eventPool "github.com/enki-polvo/polvo-logger/pool"
 )
@@ -23,7 +24,7 @@ func TestCreateNewPool(t *testing.T) {
 // Test that a valid event can be allocated from the pool
 func TestAllocateEvent(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	eventCode := eventModel.PROC_CREATE
+	eventCode := model.PROC_CREATE
 
 	event, err := pool.Allocate(eventCode)
 	if err != nil {
@@ -48,7 +49,7 @@ func TestAllocateEvent(t *testing.T) {
 // Test that an invalid event code returns an error
 func TestAllocateInvalidEvent(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+	invalidEventCode := model.EventCode(999) // Assuming 999 is not a valid event code
 
 	event, err := pool.Allocate(invalidEventCode)
 	if err == nil {
@@ -64,7 +65,7 @@ func TestAllocateInvalidEvent(t *testing.T) {
 // Test that a valid event can be freed back to the pool
 func TestFreeEvent(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	eventCode := eventModel.PROC_CREATE
+	eventCode := model.PROC_CREATE
 
 	event, err := pool.Allocate(eventCode)
 	if err != nil {
@@ -85,8 +86,8 @@ func TestFreeEvent(t *testing.T) {
 // Test that freeing an invalid event code returns an error
 func TestFreeInvalidEvent(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
-	event := &eventModel.ProcessCreateEvent{}     // Create a dummy event
+	invalidEventCode := model.EventCode(999)  // Assuming 999 is not a valid event code
+	event := &eventModel.ProcessCreateEvent{} // Create a dummy event
 
 	err := pool.Free(invalidEventCode, event)
 	if err == nil {
@@ -98,7 +99,7 @@ func TestFreeInvalidEvent(t *testing.T) {
 // This test checks the performance of allocating and freeing events in a loop
 func TestStressTestAllocateFree(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	eventCode := eventModel.PROC_CREATE
+	eventCode := model.PROC_CREATE
 
 	for i := 0; i < 1000; i++ {
 		event, err := pool.Allocate(eventCode)
@@ -122,7 +123,7 @@ func TestStressTestAllocateFree(t *testing.T) {
 // and ensures that it returns an error
 func TestStressTestAllocateInvalidEvent(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+	invalidEventCode := model.EventCode(999) // Assuming 999 is not a valid event code
 
 	for i := 0; i < 1000; i++ {
 		event, err := pool.Allocate(invalidEventCode)
@@ -141,7 +142,7 @@ func TestStressTestAllocateInvalidEvent(t *testing.T) {
 // and ensures that it returns an error
 func TestStressTestMultipleGoroutines(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	eventCode := eventModel.PROC_CREATE
+	eventCode := model.PROC_CREATE
 
 	var wg sync.WaitGroup
 	var errChan chan error
@@ -187,7 +188,7 @@ func TestStressTestMultipleGoroutines(t *testing.T) {
 // in multiple goroutines and ensures that it returns an error
 func TestStressTestInvalidInMultipleGoroutines(t *testing.T) {
 	pool := eventPool.NewEventPool()
-	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+	invalidEventCode := model.EventCode(999) // Assuming 999 is not a valid event code
 
 	var wg sync.WaitGroup
 	var errChan chan error

--- a/pool/eventPool_test.go
+++ b/pool/eventPool_test.go
@@ -1,0 +1,228 @@
+package eventPool_test
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"fmt"
+
+	eventModel "github.com/enki-polvo/polvo-logger/model/event"
+	eventPool "github.com/enki-polvo/polvo-logger/pool"
+)
+
+// Test Initialization of the event pool
+func TestCreateNewPool(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	if pool == nil {
+		t.Fatal("Failed to create new event pool")
+	}
+}
+
+// Test Allocation of a valid event
+// Test that a valid event can be allocated from the pool
+func TestAllocateEvent(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	eventCode := eventModel.PROC_CREATE
+
+	event, err := pool.Allocate(eventCode)
+	if err != nil {
+		t.Fatalf("Failed to allocate event: %v", err)
+	}
+
+	if event == nil {
+		t.Fatal("Allocated event is nil")
+	}
+
+	if _, ok := event.(*eventModel.ProcessCreateEvent); !ok {
+		t.Fatalf("Allocated event is not of type ProcessCreateEvent")
+	}
+	// Free the event back to the pool
+	err = pool.Free(eventCode, event)
+	if err != nil {
+		t.Fatalf("Failed to free event: %v", err)
+	}
+}
+
+// Test Allocation of an invalid event
+// Test that an invalid event code returns an error
+func TestAllocateInvalidEvent(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+
+	event, err := pool.Allocate(invalidEventCode)
+	if err == nil {
+		t.Fatal("Expected error when allocating invalid event, but got none")
+	}
+
+	if event != nil {
+		t.Fatal("Allocated event should be nil for invalid event code")
+	}
+}
+
+// Test Freeing of a valid event
+// Test that a valid event can be freed back to the pool
+func TestFreeEvent(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	eventCode := eventModel.PROC_CREATE
+
+	event, err := pool.Allocate(eventCode)
+	if err != nil {
+		t.Fatalf("Failed to allocate event: %v", err)
+	}
+
+	if event == nil {
+		t.Fatal("Allocated event is nil")
+	}
+
+	err = pool.Free(eventCode, event)
+	if err != nil {
+		t.Fatalf("Failed to free event: %v", err)
+	}
+}
+
+// Test Freeing of an invalid event
+// Test that freeing an invalid event code returns an error
+func TestFreeInvalidEvent(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+	event := &eventModel.ProcessCreateEvent{}     // Create a dummy event
+
+	err := pool.Free(invalidEventCode, event)
+	if err == nil {
+		t.Fatal("Expected error when freeing invalid event, but got none")
+	}
+}
+
+// Test Stress Test for Allocating and Freeing Events
+// This test checks the performance of allocating and freeing events in a loop
+func TestStressTestAllocateFree(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	eventCode := eventModel.PROC_CREATE
+
+	for i := 0; i < 1000; i++ {
+		event, err := pool.Allocate(eventCode)
+		if err != nil {
+			t.Fatalf("Failed to allocate event: %v", err)
+		}
+
+		if event == nil {
+			t.Fatal("Allocated event is nil")
+		}
+
+		err = pool.Free(eventCode, event)
+		if err != nil {
+			t.Fatalf("Failed to free event: %v", err)
+		}
+	}
+}
+
+// Test Stress Test for Allocating Invalid Events
+// This test checks the performance of allocating invalid events in a loop
+// and ensures that it returns an error
+func TestStressTestAllocateInvalidEvent(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+
+	for i := 0; i < 1000; i++ {
+		event, err := pool.Allocate(invalidEventCode)
+		if err == nil {
+			t.Fatal("Expected error when allocating invalid event, but got none")
+		}
+
+		if event != nil {
+			t.Fatal("Allocated event should be nil for invalid event code")
+		}
+	}
+}
+
+// Test Stress Test for Freeing Invalid Events in Multiple Goroutines
+// This test checks the performance of freeing invalid events in multiple goroutines
+// and ensures that it returns an error
+func TestStressTestMultipleGoroutines(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	eventCode := eventModel.PROC_CREATE
+
+	var wg sync.WaitGroup
+	var errChan chan error
+
+	errChan = make(chan error, 0)
+	defer close(errChan)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 100000; j++ {
+				event, err := pool.Allocate(eventCode)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to allocate event: %v", err)
+					return
+				}
+
+				if event == nil {
+					errChan <- fmt.Errorf("allocated event is nil")
+					return
+				}
+
+				err = pool.Free(eventCode, event)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to free event: %v", err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if len(errChan) > 0 {
+		for err := range errChan {
+			t.Log(err)
+		}
+		t.Fatal("Errors occurred during stress test")
+	}
+}
+
+// Test Stress Test for Invalid Events in Multiple Goroutines
+// This test checks the performance of allocating and freeing invalid events
+// in multiple goroutines and ensures that it returns an error
+func TestStressTestInvalidInMultipleGoroutines(t *testing.T) {
+	pool := eventPool.NewEventPool()
+	invalidEventCode := eventModel.EventCode(999) // Assuming 999 is not a valid event code
+
+	var wg sync.WaitGroup
+	var errChan chan error
+	errChan = make(chan error, 0)
+	defer close(errChan)
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				event, err := pool.Allocate(invalidEventCode)
+				if err == nil {
+					errChan <- fmt.Errorf("expected error when allocating invalid event, but got none")
+					return
+				}
+
+				if event != nil {
+					errChan <- fmt.Errorf("allocated event should be nil for invalid event code")
+					return
+				}
+				time.Sleep(1 * time.Millisecond) // Simulate some delay
+				pool.Free(invalidEventCode, event)
+				if err == nil {
+					errChan <- fmt.Errorf("expected error when freeing invalid event, but got none")
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	if len(errChan) > 0 {
+		for err := range errChan {
+			t.Log(err)
+		}
+		t.Fatal("Errors occurred during stress test")
+	}
+}


### PR DESCRIPTION
It is inevitable that `polvo` system has lots of log traffic in runtime.
I think object pooling will be efficient so I develop common event pool in `polvo-logger`.