### PR TITLE
Bug: Complete the unfinished File event structure

### DIFF
--- a/model/commonModel.go
+++ b/model/commonModel.go
@@ -15,7 +15,8 @@ const (
 	PROC_BASH_READLINE
 	PROC_SERVICE
 	TCP_EVENT
-	FILE_EVENT
+	FILE_OPEN_EVENT
+	FILE_RENAME_EVENT
 )
 
 // EventCodeToString converts an EventCode to its string representation.
@@ -31,8 +32,10 @@ func (e EventCode) String() string {
 		return "Service"
 	case TCP_EVENT:
 		return "TcpEvent"
-	case FILE_EVENT:
-		return "FileEvent"
+	case FILE_OPEN_EVENT:
+		return "FileOpenEvent"
+	case FILE_RENAME_EVENT:
+		return "FileRenameEvent"
 	default:
 		return ""
 	}

--- a/model/event/model.go
+++ b/model/event/model.go
@@ -79,16 +79,32 @@ type TcpMetadata struct {
 	Op state.TcpOp `json:"Op"` // example: "CONNECT" "DISCONNECT" "ACCEPT" etc..
 }
 
+// FileOpenMetadata defines the Metadata structure for file open events
+// for specific purposes (e.g., file opened to write data to it).
+type FileOpenMetadata struct {
+	PID               int64                   `json:"PID"`               // example: 8080
+	FileOpenerUID     int64                   `json:"FileOpenerUID"`     // example: 1200
+	FileOpenerGID     int64                   `json:"FileOpenerGID"`     // example: 1000
+	FileOwnerUID      int64                   `json:"FileOwnerUID"`      // example: 1200
+	FileOwnerGID      int64                   `json:"FileOwnerGID"`      // example: 1000
+	Mode              int64                   `json:"Mode"`              // example: 0444
+	Fmode             int64                   `json:"Fmode"`             // example: 0100644
+	FileOpenPurposeOp state.FileOpenPurposeOp `json:"FileOperationType"` // example: "FILE_OPEN_TO_WRITE"
+	Indoe             int64                   `json:"Indoe"`             // example: 17986650
+	Size              int64                   `json:"Size"`              // example: 1048576
+	ProcessName       string                  `json:"ProcessName"`       // example: "bash"
+	Path              string                  `json:"Path"`              // example: "/var/log/syslog"
+}
+
 // FileMetadata defines the Metadata structure for file events.
-type FileMetadata struct {
-	// process relation
-	PID int64 `json:"PID"` // example: 1234
-	UID int64 `json:"UID"` // example: 1000
-	// file info
-	TargetFilename string `json:"TargetFilename"` // example: "/tmp/file.txt"
-	// file operation
-	Op   state.FileOp `json:"Op"`   // example: "READ" "RENAME" "WRITE" etc..
-	Mode uint64       `json:"Mode"` // example: 0
+// It includes file open, close, and rename events.
+type FileRenameMetadata struct {
+	PID     int64  `json:"PID"`     // example: 8080
+	UID     int64  `json:"UID"`     // example: 1200
+	GID     int64  `json:"GID"`     // example: 1000
+	Command string `json:"Command"` // example: "mv"
+	OldPath string `json:"OldPath"` // example: "/var/log/syslog"
+	NewPath string `json:"NewPath"` // example: "/var/log/syslog.backup"
 }
 
 // --------------------------------------------------
@@ -125,8 +141,14 @@ type TcpEvent struct {
 	Metadata TcpMetadata `json:"Metadata"`
 }
 
-// FileEvent defines the event structure for file events.
-type FileEvent struct {
+// FileRenameEvent defines the event structure for file rename events.
+type FileOpenEvent struct {
 	commonModel.CommonHeader
-	Metadata FileMetadata `json:"Metadata"`
+	Metadata FileOpenMetadata `json:"Metadata"`
+}
+
+// FileRenameEvent defines the event structure for file rename events.
+type FileRenameEvent struct {
+	commonModel.CommonHeader
+	Metadata FileRenameMetadata `json:"Metadata"`
 }

--- a/model/event/model.go
+++ b/model/event/model.go
@@ -15,16 +15,11 @@ type Event any
 
 // ProcessCreateMetadata defines the Metadata structure for process creation events.
 type ProcessCreateMetadata struct {
-	// process relation
-	PID  int64 `json:"PID"`  // example: 1234
-	PPID int64 `json:"PPID"` // example: 4
-
-	// user info
-	UID      int64  `json:"UID"`      // example: 1000
-	Username string `json:"Username"` // example: "root"
-	TGID     int64  `json:"TGID"`     // example: 1234
-
-	// process info
+	PID         int64  `json:"PID"`         // example: 1234
+	PPID        int64  `json:"PPID"`        // example: 4
+	UID         int64  `json:"UID"`         // example: 1000
+	Username    string `json:"Username"`    // example: "root"
+	TGID        int64  `json:"TGID"`        // example: 1234
 	Commandline string `json:"Commandline"` // example: "bash rm -rf /tmp"
 	ENV         string `json:"ENV"`         // example: "PATH=/usr/bin:/bin"
 	Image       string `json:"Image"`       // example: "/usr/bin/bash"
@@ -32,28 +27,18 @@ type ProcessCreateMetadata struct {
 
 // ProcessTerminateMetadata defines the Metadata structure for process termination events.
 type ProcessTerminateMetadata struct {
-	// process relation
-	PID int64 `json:"PID"` // example: 1234
-
-	// process info
-	Ret int64 `json:"Ret"` // example: 0
-
-	// user info
+	PID      int64  `json:"PID"`      // example: 1234
+	Ret      int64  `json:"Ret"`      // example: 0
 	UID      int64  `json:"UID"`      // example: 1000
 	Username string `json:"Username"` // example: "root"
 }
 
 // BashReadlineMetadata defines the Metadata structure for bash readline events.
 type BashReadlineMetadata struct {
-	// process relation
-	PID int64 `json:"PID"` // example: 1234
-
-	// info
+	PID         int64  `json:"PID"`         // example: 1234
 	Commandline string `json:"Commandline"` // example: "bash rm -rf /tmp"
-
-	// user info
-	UID      int64  `json:"UID"`      // example: 1000
-	Username string `json:"Username"` // example: "root"
+	UID         int64  `json:"UID"`         // example: 1000
+	Username    string `json:"Username"`    // example: "root"
 }
 
 // ServiceMetadata defines the Metadata structure for service events.
@@ -67,16 +52,13 @@ type ServiceMetadata struct {
 
 // TcpMetadata defines the Metadata structure for TCP events.
 type TcpMetadata struct {
-	// process  relation
-	PID int64 `json:"PID"` // example: 1234
-	// tcp info
-	Daddr    string `json:"Daddr"`    // example: "127.0.0.1"
-	Dport    int64  `json:"Dport"`    // example: 80
-	Saddr    string `json:"Saddr"`    // example: "127.0.0.1"
-	Sport    int64  `json:"Sport"`    // example: 80
-	Protocol int64  `json:"Protocol"` // example: 4
-	// tcp operation
-	Op state.TcpOp `json:"Op"` // example: "CONNECT" "DISCONNECT" "ACCEPT" etc..
+	PID      int64       `json:"PID"`      // example: 1234
+	Daddr    string      `json:"Daddr"`    // example: "127.0.0.1"
+	Dport    int64       `json:"Dport"`    // example: 80
+	Saddr    string      `json:"Saddr"`    // example: "127.0.0.1"
+	Sport    int64       `json:"Sport"`    // example: 80
+	Protocol int64       `json:"Protocol"` // example: 4
+	Op       state.TcpOp `json:"Op"`       // example: "CONNECT" "DISCONNECT" "ACCEPT" etc..
 }
 
 // FileOpenMetadata defines the Metadata structure for file open events
@@ -109,45 +91,40 @@ type FileRenameMetadata struct {
 
 // --------------------------------------------------
 // System events Metadata
+//
+// They define the event structures for each type of event.
 // --------------------------------------------------
 
-// ProcessCreateEvent defines the event structure for process creation events.
 type ProcessCreateEvent struct {
 	commonModel.CommonHeader
 	Metadata ProcessCreateMetadata `json:"Metadata"`
 }
 
-// ProcessTerminateEvent defines the event structure for process termination events.
 type ProcessTerminateEvent struct {
 	commonModel.CommonHeader
 	Metadata ProcessTerminateMetadata `json:"Metadata"`
 }
 
-// BashReadlineEvent defines the event structure for bash readline events.
 type BashReadlineEvent struct {
 	commonModel.CommonHeader
 	Metadata BashReadlineMetadata `json:"Metadata"`
 }
 
-// ServiceEvent defines the event structure for service events.
 type ServiceEvent struct {
 	commonModel.CommonHeader
 	Metadata ServiceMetadata `json:"Metadata"`
 }
 
-// TcpEvent defines the event structure for TCP events.
 type TcpEvent struct {
 	commonModel.CommonHeader
 	Metadata TcpMetadata `json:"Metadata"`
 }
 
-// FileRenameEvent defines the event structure for file rename events.
 type FileOpenEvent struct {
 	commonModel.CommonHeader
 	Metadata FileOpenMetadata `json:"Metadata"`
 }
 
-// FileRenameEvent defines the event structure for file rename events.
 type FileRenameEvent struct {
 	commonModel.CommonHeader
 	Metadata FileRenameMetadata `json:"Metadata"`

--- a/model/state/stateConstants.go
+++ b/model/state/stateConstants.go
@@ -16,6 +16,19 @@ const (
 	REUP
 )
 
+func (s State) String() string {
+	switch s {
+	case CREATED:
+		return "CREATED"
+	case MODIFIED:
+		return "MODIFIED"
+	case REUP:
+		return "REUP"
+	default:
+		return ""
+	}
+}
+
 // FileOpenPurposeOp defines the purposes of a specific file open operation
 type FileOpenPurposeOp int
 
@@ -30,6 +43,21 @@ const (
 	FILE_OPEN_TO_OTHER
 )
 
+func (f FileOpenPurposeOp) String() string {
+	switch f {
+	case FILE_OPEN_TO_UNSET:
+		return "FILE_OPEN_TO_UNSET"
+	case FILE_OPEN_TO_READ:
+		return "FILE_OPEN_TO_READ"
+	case FILE_OPEN_TO_WRITE:
+		return "FILE_OPEN_TO_WRITE"
+	case FILE_OPEN_TO_OTHER:
+		return "FILE_OPEN_TO_OTHER"
+	default:
+		return ""
+	}
+}
+
 // TcpOp defines the TCP operation types.
 type TcpOp int
 
@@ -43,3 +71,18 @@ const (
 	// TCP connection acceptance
 	TCP_ACCEPT
 )
+
+func (t TcpOp) String() string {
+	switch t {
+	case TCP_OP_UNSET:
+		return "TCP_OP_UNSET"
+	case TCP_CONNECT:
+		return "TCP_CONNECT"
+	case TCP_DISCONNECT:
+		return "TCP_DISCONNECT"
+	case TCP_ACCEPT:
+		return "TCP_ACCEPT"
+	default:
+		return ""
+	}
+}

--- a/model/state/stateConstants.go
+++ b/model/state/stateConstants.go
@@ -16,22 +16,18 @@ const (
 	REUP
 )
 
-// FileOp defines the file operation types.
-type FileOp int
+// FileOpenPurposeOp defines the purposes of a specific file open operation
+type FileOpenPurposeOp int
 
 const (
 	// default value for FileOp
-	FILE_OP_UNSET FileOp = iota
-	// File creation
-	FILE_CREATE
-	// File deletion
-	FILE_DELETE
-	// File read
-	FILE_READ
-	// File write
-	FILE_WRITE
-	// File rename
-	FILE_RENAME
+	FILE_OPEN_TO_UNSET FileOpenPurposeOp = iota
+	// File opened to read data from it
+	FILE_OPEN_TO_READ
+	// File opened to write data to it
+	FILE_OPEN_TO_WRITE
+	// File opened to do something else that is not belonged to read or write
+	FILE_OPEN_TO_OTHER
 )
 
 // TcpOp defines the TCP operation types.

--- a/pool/eventPool.go
+++ b/pool/eventPool.go
@@ -57,14 +57,20 @@ var (
 			}
 			return obj
 		},
-		model.FILE_EVENT: func() any {
+		model.FILE_OPEN_EVENT: func() any {
 			obj := &model.CommonModel{}
-			obj.CommonHeader.EventCode = model.FILE_EVENT
-			obj.CommonHeader.EventName = model.FILE_EVENT.String()
-			// Initialize the metadata Opcode for File events
-			obj.Metadata = &eventModel.FileMetadata{
-				Op: stateConstants.FILE_OP_UNSET, // default value
+			obj.CommonHeader.EventCode = model.FILE_OPEN_EVENT
+			obj.CommonHeader.EventName = model.FILE_OPEN_EVENT.String()
+			// Initalize the metadata Opcode for File Open events
+			obj.Metadata = &eventModel.FileOpenMetadata{
+				FileOpenPurposeOp: stateConstants.FILE_OPEN_TO_UNSET, // default value
 			}
+			return obj
+		},
+		model.FILE_RENAME_EVENT: func() any {
+			obj := &model.CommonModel{}
+			obj.CommonHeader.EventCode = model.FILE_RENAME_EVENT
+			obj.CommonHeader.EventName = model.FILE_RENAME_EVENT.String()
 			return obj
 		},
 	}


### PR DESCRIPTION
As addressed in issue #23, the log formats for file events were insufficient and incomplete. I completed the event data format definition. Now that this type of event has been categorized into two distinct types: File Open event and File Rename event.